### PR TITLE
优化 MutationObserver 回调，避免内存泄露

### DIFF
--- a/fix-sinaimg.user.js
+++ b/fix-sinaimg.user.js
@@ -15,33 +15,88 @@
 // @supportURL        https://github.com/itorr/fix-sinaimg.user.js/issues
 // ==/UserScript==
 
+const blobUrlSet = new Set();
+const isSinaImageRegex = /^https?:\/\/([^/]+\.|)sinaimg\.cn\//;
 
-const isSinaImageRegex = /sinaimg\.cn\//;
-const fixSinaImages = ()=>{
-    [...document.images].filter(el=>isSinaImageRegex.test(el.src)).forEach(el=>{
-        GM_xmlhttpRequest({
-            method:'GET',
-            url: el.src,
-            responseType: 'blob',
-            headers: {
-                'referer': 'https://weibo.com/mygroups'
-            },
-            onload(res){
-                el.src = URL.createObjectURL(res.response);
-            }
-        });
-        el.removeAttribute('src');
+const fixSinaImages = () => {
+    [...document.images].forEach(fixSinaImage);
+};
+const fixSinaImage = el => {
+    if (!isSinaImageRegex.test(el.src)) return;
+    GM_xmlhttpRequest({
+        method: 'GET',
+        url: el.src,
+        responseType: 'blob',
+        headers: {
+            referer: 'https://weibo.com/mygroups',
+        },
+        onload(res) {
+            const url = URL.createObjectURL(res.response);
+            blobUrlSet.add(url);
+            el.src = url;
+        },
+    });
+    el.removeAttribute('src');
+};
+
+const fixSinaImagesForObserver = mutationList => {
+    mutationList.forEach(asd => {
+        const { type, target, attributeName, oldValue, addedNodes, removedNodes } = asd;
+        // 有节点新增时，处理 url，不用去完整遍历 document.images
+        if (addedNodes.length) {
+            addedNodes.forEach(node => {
+                if (!(node instanceof Element)) return;
+                // 节点本身是 img
+                if (node.tagName === 'IMG') {
+                    fixSinaImage(node);
+                    return;
+                }
+                // 子节点有 img
+                node.querySelectorAll('img').forEach(fixSinaImage);
+            });
+        }
+        // 有节点被删除时，释放 blob url
+        if (removedNodes.length) {
+            removedNodes.forEach(node => {
+                if (!(node instanceof Element)) return;
+                // 节点本身是 img
+                if (node.tagName === 'IMG') {
+                    revokeBlobUrlFromImage(node);
+                    return;
+                }
+                // 子节点有 img
+                node.querySelectorAll('img').forEach(revokeBlobUrlFromImage);
+            });
+        }
+        // 当 src 被修改时
+        if (type === 'attributes' && attributeName === 'src') {
+            // 旧 src 是 blob url，需要释放
+            if (blobUrlSet.has(oldValue)) revokeBlobUrl(oldValue);
+            // 处理新 src
+            fixSinaImage(target);
+        }
     });
 };
 
-if(window.MutationObserver){
-    (new MutationObserver(fixSinaImages)).observe(document.body,{
+const revokeBlobUrlFromImage = img => {
+    if (!blobUrlSet.has(img.src)) return;
+    revokeBlobUrl(img.url);
+};
+const revokeBlobUrl = url => {
+    URL.revokeObjectURL(url);
+    blobUrlSet.delete(url);
+};
+
+if (window.MutationObserver) {
+    new MutationObserver(fixSinaImagesForObserver).observe(document.body, {
         childList: true,
         subtree: true,
         attributes: true,
+        attributeOldValue: true,
+        attributeFilter: ['src'],
     });
-}else{
-    document.addEventListener('DOMNodeInserted',fixSinaImages);
+} else {
+    document.addEventListener('DOMNodeInserted', fixSinaImages);
 }
 
-window.addEventListener('load',fixSinaImages);
+window.addEventListener('load', fixSinaImages);


### PR DESCRIPTION
进行了亿点点更改……

1. 在图片被移除时应调用 `URL.revokeObjectURL()`，否则可能会导致内存泄露
2. 将 sinaimg 正则改的严格了一点，避免可能的误伤
3. 稍微重构了一下，并且针对 MutationObserver 的场合直接从 MutationRecord 里面拿节点修复新浪图片，避免每次都去遍历 `document.images`
4. 设置 `attributeFilter` 可以过滤掉一些不必要的通知

------

版本号没有修改，看了下 commit 发现 0.1 -> 0.11 😂